### PR TITLE
Size specifications, IE7 fix and dynamic styles

### DIFF
--- a/backgroundsize.htc
+++ b/backgroundsize.htc
@@ -200,7 +200,7 @@ function updateBackground( element, expando ) {
 			}
 		}
 
-	} else if ( expando.backgroundSize == "cover" ) {
+	} else if ( backgroundSize == "cover" ) {
 		if ( imgRatio > elemRatio ) {
 			expando.constrain = curConstrain = "height";
 

--- a/backgroundsize.htc
+++ b/backgroundsize.htc
@@ -20,8 +20,7 @@ init();
 function init() {
 	var wrapper = doc.createElement( "div" ),
 		img = doc.createElement( "img" ),
-		expando,
-		pos;
+		expando;
 
 	wrapper.style.position = "absolute";
 	wrapper.style.zIndex = -1;
@@ -47,11 +46,7 @@ function init() {
 	// save useful data for quick access
 	element.bgsExpando = expando = {
 		wrapper: wrapper,
-		img: img,
-		backgroundSize: element.currentStyle['background-size'],
-		// Only keywords or percentage values are supported
-		backgroundPositionX: positions[ pos[0] ] || parseFloat( pos[0] ) / 100,
-		backgroundPositionY: positions[ pos[1] ] || parseFloat( pos[1] ) / 100
+		img: img
 	};
 
 	// This is the part where we mess with the existing DOM
@@ -148,15 +143,33 @@ function updateBackground( element, expando ) {
 		imgRatio = expando.imgWidth / expando.imgHeight,
 		prevConstrain = expando.constrain,
 		curConstrain,
-		delta;
+		delta,
+		explicit_size,
+		pos,
+		backgroundSize,
+		backgroundPositionX,
+		backgroundPositionY;
 
-	if ( expando.backgroundSize == "contain" ) {
+	pos = [
+		element.currentStyle.backgroundPositionX,
+		element.currentStyle.backgroundPositionY
+	];
+  backgroundSize = element.currentStyle['background-size'];
+  // Only keywords or percentage values are supported
+	backgroundPositionX = positions[ pos[0] ]
+	if(typeof backgroundPositionX == "undefined")
+	  backgroundPositionX = parseFloat( pos[0] ) / 100;
+	backgroundPositionY = positions[ pos[1] ]
+	if(typeof backgroundPositionY == "undefined")
+	  backgroundPositionY = parseFloat( pos[1] ) / 100;
+
+	if ( backgroundSize == "contain" ) {
 		if ( imgRatio > elemRatio ) {
 			expando.constrain = curConstrain = "width";
 
 			delta = Math.floor(
 				( expando.innerHeight - expando.innerWidth / imgRatio )
-				* expando.backgroundPositionY
+				* backgroundPositionY
 			);
 
 			img.style.top = delta + "px";
@@ -175,7 +188,7 @@ function updateBackground( element, expando ) {
 
 			delta = Math.floor(
 				( expando.innerWidth - expando.innerHeight * imgRatio )
-				* expando.backgroundPositionX
+				* backgroundPositionX
 			);
 
 			img.style.left = delta + "px";
@@ -193,7 +206,7 @@ function updateBackground( element, expando ) {
 
 			delta = Math.floor(
 				( expando.innerHeight * imgRatio - expando.innerWidth )
-				* expando.backgroundPositionX
+				* backgroundPositionX
 			);
 
 			img.style.left = -delta + "px";
@@ -212,7 +225,7 @@ function updateBackground( element, expando ) {
 
 			delta = Math.floor(
 				( expando.innerWidth / imgRatio - expando.innerHeight )
-				* expando.backgroundPositionY
+				* backgroundPositionY
 			);
 
 			img.style.top = -delta + "px";
@@ -223,6 +236,21 @@ function updateBackground( element, expando ) {
 				img.style.left = 0;
 			}
 		}
+	} else {
+	  explicit_size = backgroundSize.split(' ');
+	  if( explicit_size.length == 1 ) explicit_size[1] = 'auto';
+	  img.style.width = explicit_size[0];
+	  img.style.height = explicit_size[1];
+		delta = Math.floor(
+			( expando.innerHeight * imgRatio - expando.innerWidth )
+			* backgroundPositionX
+		);
+		img.style.left = -delta + "px";
+		delta = Math.floor(
+			( expando.innerWidth / imgRatio - expando.innerHeight )
+			* backgroundPositionY
+		);
+		img.style.top = -delta + "px";
 	}
 
 	expando.somethingChanged = false;


### PR DESCRIPTION
When using this polyfill I found the following issues:
- It was caching the size and position info. This isn't compatible
    with this information getting changed dynamically (for example
    through @media styles).
- Added support for specifying exact sizes.
    For example background-size: 100% 100%
- Fixed issue where top was not working because 0
  evaluates to false.
- There was a extra comma that caused problems in IE7.

This is a rough patch. I basically just fixed it up for my website,
copy and pasted the final code into GitHub and submitted the patch
in hopes it is useful to someone else. If I get a chance down the
road I can try to make a proper patch (commit for each issue I am
fixing and more extensive testing to make sure I didn't break
anything). But I figured a messy patch is better than no patch if
this helps someone out and I never get a chance to clean it up.
