### PR TITLE
Fix for the script's XML wrapping tags

### DIFF
--- a/backgroundsize.htc
+++ b/backgroundsize.htc
@@ -1,7 +1,7 @@
-<component lightWeight="true">
-<attach event="onpropertychange" onevent="handlePropertychange()" />
-<attach event="ondetach" onevent="restore()" />
-<attach event="onresize" for="window" onevent="handleResize()" />
+<public:component lightWeight="true">
+<public:attach event="onpropertychange" onevent="handlePropertychange()" />
+<public:attach event="ondetach" onevent="restore()" />
+<public:attach event="onresize" for="window" onevent="handleResize()" />
 <script type="text/javascript">
 
 var rsrc = /url\(["']?(.*?)["']?\)/,
@@ -269,3 +269,4 @@ function restore() {
 }
 
 </script>
+</public:component>


### PR DESCRIPTION
Updated htc-document tags in accordance with Microsoft guide:
http://msdn.microsoft.com/en-us/subscriptions/ms532146(v=vs.85).aspx#HTC
Even though public:component is optional, the xml document without closing tag can be parsed with unexpected results. In my test case the script was ignored completely (no behavior applied to elements).
Adding these changes helped me to fix the issue.
