### PR TITLE
expando.backgroundPosition{X,Y} wrong if e.g. set to 'top'

### DIFF
--- a/backgroundsize.htc
+++ b/backgroundsize.htc
@@ -50,8 +50,9 @@ function init() {
 		img: img,
 		backgroundSize: element.currentStyle['background-size'],
 		// Only keywords or percentage values are supported
-		backgroundPositionX: positions[ pos[0] ] || parseFloat( pos[0] ) / 100,
-		backgroundPositionY: positions[ pos[1] ] || parseFloat( pos[1] ) / 100
+		backgroundPositionX: (typeof  positions[ pos[0] ] == "number" ? positions[ pos[0] ] : parseFloat( pos[0] )) / 100,
+		backgroundPositionY: (typeof  positions[ pos[1] ] == "number" ? positions[ pos[1] ] : parseFloat( pos[1] )) / 100
+
 	};
 
 	// This is the part where we mess with the existing DOM


### PR DESCRIPTION
if pos[1] is 'top', positions[pos[1]] evaluates to zero, which is falsy. Then backgroundPositionY will be set to parseFloat("top") / 100 == NaN
